### PR TITLE
Add new transport parameter

### DIFF
--- a/quic/core/crypto/transport_parameters.cc
+++ b/quic/core/crypto/transport_parameters.cc
@@ -1252,6 +1252,7 @@ bool SerializeTransportParameters(ParsedQuicVersion /*version*/,
       } break;
       case TransportParameters::kMulticastClientParams: {
         if (in.multicast_client_params.has_value()){
+          //TODO: Strip output 
           printf("%s", in.multicast_client_params->ToString().c_str());
           uint8_t fb = 0;
           if (in.multicast_client_params.value().permitIPv4){

--- a/quic/core/crypto/transport_parameters.cc
+++ b/quic/core/crypto/transport_parameters.cc
@@ -1235,6 +1235,11 @@ bool SerializeTransportParameters(ParsedQuicVersion /*version*/,
           }
         }
       } break;
+      case TransportParameters::kMulticastClientParams: {
+        if (in.multicast_client_params.has_value()){
+          printf("\n Got multicast parameters set. \n");
+        }
+      } break;
       // Custom parameters and GREASE.
       default: {
         auto it = custom_parameters.find(parameter_id);

--- a/quic/core/crypto/transport_parameters.cc
+++ b/quic/core/crypto/transport_parameters.cc
@@ -345,7 +345,7 @@ std::ostream& operator<<(
   os << multicast_client_params.ToString();
   return os;
 }
-
+// TODO: Properly convert to string (after picking correct types)
 std::string TransportParameters::MulticastClientParams::ToString() const {
   return "Multicast present";
 }
@@ -1236,8 +1236,14 @@ bool SerializeTransportParameters(ParsedQuicVersion /*version*/,
         }
       } break;
       case TransportParameters::kMulticastClientParams: {
+        // TODO: Send the parameters (after picking correct types)
         if (in.multicast_client_params.has_value()){
-          printf("\n Got multicast parameters set. \n");
+            if (!writer.WriteVarInt62(TransportParameters::kMulticastClientParams)) {
+            QUIC_BUG(Failed to write other version)
+                << "Failed to write other version for " << in;
+            return false;
+          }
+          std::cout << "\n Got multicast parameters set. \n" << in.multicast_client_params.value().ToString();
         }
       } break;
       // Custom parameters and GREASE.

--- a/quic/core/crypto/transport_parameters.h
+++ b/quic/core/crypto/transport_parameters.h
@@ -132,7 +132,6 @@ struct QUIC_EXPORT_PRIVATE TransportParameters {
 
     bool permitIPv4;
     bool permitIPv6;
-    //TODO: Use proper types/variable length integers
     uint64_t maxAggregateRate;
     uint64_t maxChannelIDs;
     uint64_t hashAlgorithmsSupported;

--- a/quic/core/crypto/transport_parameters.h
+++ b/quic/core/crypto/transport_parameters.h
@@ -109,7 +109,41 @@ struct QUIC_EXPORT_PRIVATE TransportParameters {
         std::ostream& os,
         const TransportParameters& params);
   };
+  //multicast_client_params {
+    //Permit IPv4 (1),
+    //Permit IPv6 (1),
+    //Reserved (6),
+    //Max Aggregate Rate (i),
+    //Max Session IDs (i),
+    //Hash Algorithms Supported (i),
+    //AEAD Algorithms Supported (i),
+    //Hash Algorithms List (16 * Hash Algorithms Supported),
+    //AEAD Algorithms List (16 * AEAD Algorithms Supported)
+  //}
+  struct QUIC_EXPORT_PRIVATE  MulticastClientParams {
+    // I do not know what any of this does...
+    MulticastClientParams();
+    MulticastClientParams(const MulticastClientParams& other) = default;
+    MulticastClientParams(MulticastClientParams&& other) = default;
+    ~MulticastClientParams();
+    bool operator==(const MulticastClientParams& rhs) const;
+    bool operator!=(const MulticastClientParams& rhs) const;
 
+    bool permitIPv4;
+    bool permitIPv6;
+    //TODO: Use proper types/variable length integers
+    int maxAggregateRate;
+    int maxSessionIDs;
+    int hashAlgorithmsSupported;
+    int aeadAlgorithmsSupported;
+    std::vector<uint8_t> hashAlgorithmsList;
+    std::vector<uint8_t> aeadAlgorithmsList;
+
+    std::string ToString() const;
+    friend QUIC_EXPORT_PRIVATE std::ostream& operator<<(
+        std::ostream& os,
+        const TransportParameters& params);
+  };
   // LegacyVersionInformation represents the Google QUIC downgrade prevention
   // mechanism ported to QUIC+TLS. It is exchanged using transport parameter ID
   // 0x4752 and will eventually be deprecated in favor of
@@ -190,6 +224,9 @@ struct QUIC_EXPORT_PRIVATE TransportParameters {
   // The value of the Destination Connection ID field from the first
   // Initial packet sent by the client.
   absl::optional<QuicConnectionId> original_destination_connection_id;
+
+  // Multicast parameter
+  absl::optional<MulticastClientParams> multicast_client_params;
 
   // Maximum idle timeout expressed in milliseconds.
   IntegerParameter max_idle_timeout_ms;

--- a/quic/core/crypto/transport_parameters.h
+++ b/quic/core/crypto/transport_parameters.h
@@ -121,10 +121,11 @@ struct QUIC_EXPORT_PRIVATE TransportParameters {
     //AEAD Algorithms List (16 * AEAD Algorithms Supported)
   //}
   struct QUIC_EXPORT_PRIVATE  MulticastClientParams {
-    // I do not know what any of this does...
+    // Overloaded operators
     MulticastClientParams();
     MulticastClientParams(const MulticastClientParams& other) = default;
-    MulticastClientParams(MulticastClientParams&& other) = default;
+    // Allows for copying which is probably not optimal...
+    //MulticastClientParams(MulticastClientParams&& other) = default;
     ~MulticastClientParams();
     bool operator==(const MulticastClientParams& rhs) const;
     bool operator!=(const MulticastClientParams& rhs) const;

--- a/quic/core/crypto/transport_parameters.h
+++ b/quic/core/crypto/transport_parameters.h
@@ -133,12 +133,12 @@ struct QUIC_EXPORT_PRIVATE TransportParameters {
     bool permitIPv4;
     bool permitIPv6;
     //TODO: Use proper types/variable length integers
-    int maxAggregateRate;
-    int maxSessionIDs;
-    int hashAlgorithmsSupported;
-    int aeadAlgorithmsSupported;
-    std::vector<uint8_t> hashAlgorithmsList;
-    std::vector<uint8_t> aeadAlgorithmsList;
+    uint64_t maxAggregateRate;
+    uint64_t maxChannelIDs;
+    uint64_t hashAlgorithmsSupported;
+    uint64_t aeadAlgorithmsSupported;
+    std::vector<uint16_t> hashAlgorithmsList;
+    std::vector<uint16_t> aeadAlgorithmsList;
 
     std::string ToString() const;
     friend QUIC_EXPORT_PRIVATE std::ostream& operator<<(

--- a/quic/core/quic_config.cc
+++ b/quic/core/quic_config.cc
@@ -1182,6 +1182,19 @@ QuicErrorCode QuicConfig::ProcessPeerHello(
   return error;
 }
 
+void QuicConfig::SetMulticastParams(    
+    bool permitIPv4,
+    bool permitIPv6,
+    //TODO: Use proper types/variable length integers
+    int maxAggregateRate,
+    int maxSessionIDs,
+    int hashAlgorithmsSupported,
+    int aeadAlgorithmsSupported,
+    std::vector<uint8_t> hashAlgorithmsList,
+    std::vector<uint8_t> aeadAlgorithmsList) {
+      //multicast_client_params_ =  &new TransportParameters::MulticastClientParams();
+    }
+
 bool QuicConfig::FillTransportParameters(TransportParameters* params) const {
   if (original_destination_connection_id_to_send_.has_value()) {
     params->original_destination_connection_id =
@@ -1280,6 +1293,8 @@ bool QuicConfig::FillTransportParameters(TransportParameters* params) const {
   }
 
   params->custom_parameters = custom_transport_parameters_to_send_;
+
+
 
   return true;
 }

--- a/quic/core/quic_config.cc
+++ b/quic/core/quic_config.cc
@@ -1182,25 +1182,16 @@ QuicErrorCode QuicConfig::ProcessPeerHello(
   return error;
 }
 
-void QuicConfig::SetMulticastParams(    
-    bool permitIPv4,
-    bool permitIPv6,
-    //TODO: Use proper types/variable length integers
-    int maxAggregateRate,
-    int maxSessionIDs,
-    int hashAlgorithmsSupported,
-    int aeadAlgorithmsSupported,
-    std::vector<uint8_t> hashAlgorithmsList,
-    std::vector<uint8_t> aeadAlgorithmsList) {
-      //multicast_client_params_ =  &new TransportParameters::MulticastClientParams();
-    }
+void QuicConfig::SetMulticastParams() {
+      multicast_client_params_ = TransportParameters::MulticastClientParams();
+  }
 
 bool QuicConfig::FillTransportParameters(TransportParameters* params) const {
   if (original_destination_connection_id_to_send_.has_value()) {
     params->original_destination_connection_id =
         original_destination_connection_id_to_send_.value();
   }
-
+  
   params->max_idle_timeout_ms.set_value(
       max_idle_timeout_to_send_.ToMilliseconds());
 
@@ -1294,7 +1285,9 @@ bool QuicConfig::FillTransportParameters(TransportParameters* params) const {
 
   params->custom_parameters = custom_transport_parameters_to_send_;
 
-
+  if (multicast_client_params_.has_value()) {
+    params->multicast_client_params = multicast_client_params_.value();
+  }
 
   return true;
 }

--- a/quic/core/quic_config.h
+++ b/quic/core/quic_config.h
@@ -512,16 +512,7 @@ class QUIC_EXPORT_PRIVATE QuicConfig {
     return received_custom_transport_parameters_;
   }
 
-  void SetMulticastParams(    
-    bool permitIPv4,
-    bool permitIPv6,
-    //TODO: Use proper types/variable length integers
-    int maxAggregateRate,
-    int maxSessionIDs,
-    int hashAlgorithmsSupported,
-    int aeadAlgorithmsSupported,
-    std::vector<uint8_t> hashAlgorithmsList,
-    std::vector<uint8_t> aeadAlgorithmsList);
+  void SetMulticastParams();
 
  private:
   friend class test::QuicConfigPeer;

--- a/quic/core/quic_config.h
+++ b/quic/core/quic_config.h
@@ -512,6 +512,17 @@ class QUIC_EXPORT_PRIVATE QuicConfig {
     return received_custom_transport_parameters_;
   }
 
+  void SetMulticastParams(    
+    bool permitIPv4,
+    bool permitIPv6,
+    //TODO: Use proper types/variable length integers
+    int maxAggregateRate,
+    int maxSessionIDs,
+    int hashAlgorithmsSupported,
+    int aeadAlgorithmsSupported,
+    std::vector<uint8_t> hashAlgorithmsList,
+    std::vector<uint8_t> aeadAlgorithmsList);
+
  private:
   friend class test::QuicConfigPeer;
 
@@ -658,6 +669,9 @@ class QUIC_EXPORT_PRIVATE QuicConfig {
   // handshake.
   TransportParameters::ParameterMap custom_transport_parameters_to_send_;
   TransportParameters::ParameterMap received_custom_transport_parameters_;
+
+  // Multicast parameters
+  absl::optional<TransportParameters::MulticastClientParams> multicast_client_params_;
 };
 
 }  // namespace quic

--- a/quic/tools/quic_toy_client.cc
+++ b/quic/tools/quic_toy_client.cc
@@ -290,7 +290,7 @@ int QuicToyClient::SendRequestsAndPrintResponses(
   std::string connection_options_string = GetQuicFlag(FLAGS_connection_options);
 
   if (GetQuicFlag(FLAGS_multicast)) {
-    //config.multicast_client_params_ = NULL;
+    config.SetMulticastParams();
   }
   if (!connection_options_string.empty()) {
     config.SetConnectionOptionsToSend(

--- a/quic/tools/quic_toy_client.cc
+++ b/quic/tools/quic_toy_client.cc
@@ -186,6 +186,9 @@ DEFINE_QUICHE_COMMAND_LINE_FLAG(
     int32_t, max_inbound_header_list_size, 128 * 1024,
     "Max inbound header list size. 0 means default.");
 
+DEFINE_QUICHE_COMMAND_LINE_FLAG(bool, multicast, false, 
+                                "If true, use multicast.");
+
 namespace quic {
 namespace {
 
@@ -494,6 +497,16 @@ int QuicToyClient::SendRequestsAndPrintResponses(
       }
     }
   }
+
+  if (GetQuicFlag(FLAGS_multicast))
+  {
+    while (true)
+    {
+      /* code */
+    }
+    
+  }
+  
 
   return 0;
 }

--- a/quic/tools/quic_toy_client.cc
+++ b/quic/tools/quic_toy_client.cc
@@ -504,11 +504,7 @@ int QuicToyClient::SendRequestsAndPrintResponses(
 
   if (GetQuicFlag(FLAGS_multicast))
   {
-    while (true)
-    {
-      /* code */
-    }
-    
+    client->WaitForStreamToClose(1);
   }
   
 

--- a/quic/tools/quic_toy_client.cc
+++ b/quic/tools/quic_toy_client.cc
@@ -288,6 +288,10 @@ int QuicToyClient::SendRequestsAndPrintResponses(
 
   QuicConfig config;
   std::string connection_options_string = GetQuicFlag(FLAGS_connection_options);
+
+  if (GetQuicFlag(FLAGS_multicast)) {
+    //config.multicast_client_params_ = NULL;
+  }
   if (!connection_options_string.empty()) {
     config.SetConnectionOptionsToSend(
         ParseQuicTagVector(connection_options_string));


### PR DESCRIPTION
Currently only uses the default values from the constructor, should maybe consider adding guidance on good defaults to the draft. Also discuss good way to set them, probably something like TAPS transport properties where you create the object first then hand it over? Its a lot so just passing them into the call might not be ideal. 